### PR TITLE
Add labels and annotations to the argument spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,35 @@ Contains the following modules:
 Note that the activation command (minus the `--worker`, `--etcd`, or `--controlplane` flags) is returned as 
 `registration_token`.
 
+The following shows a more complete example of the usage of the `rancher_cluster` module including all optional parameters:
+
+```yaml
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: Create rancher cluster including optional parameters
+    rancher_cluster:
+      name: test-cluster2
+      description: Another test cluster created via Ansible
+      rancher_url: https://rancher.mydomain.com
+      api_bearer_key: token-xyz:abcdefg0123456789
+      network_plugin: calico
+      agentImageOverride: my-org/my-image
+      desiredAgentImage: my-org/my-image
+      desiredAuthImage: my-org/my-image
+      dockerRootDir: /var/lib/docker
+      enableClusterAlerting: True
+      enableClusterMonitoring: True
+      ignore_docker_version: True
+      validate_certs: True
+      labels:
+        mylabel: Value
+        other_label: Value
+      annotations:
+        first_annotation: "Value"
+        second_annotation: "Another value"
+```
+
 #### rancher_node
 
 ```yaml

--- a/plugins/modules/rancher_cluster.py
+++ b/plugins/modules/rancher_cluster.py
@@ -148,6 +148,8 @@ def main():
         "enableClusterMonitoring": {"default": False, "type": "bool"},
         "ignore_docker_version": {"default": False, "type": "bool"},
         "validate_certs": {"default": True, "type": "bool"},
+        "labels": {"required": False, "type": "dict"},
+        "annotations": {"required": False, "type": "dict"},
         "network_plugin": {
             "default": "canal",
             "choices": ["canal", "calico", "flannel"],


### PR DESCRIPTION
With this addition we are able to add annotations and labels to a newly created cluster. 