### PR TITLE
[FIX] Add no_log to api_bearer_key field

### DIFF
--- a/plugins/modules/rancher_cluster.py
+++ b/plugins/modules/rancher_cluster.py
@@ -138,7 +138,7 @@ def main():
     fields = {
         "name": {"required": True, "type": "str"},
         "rancher_url": {"required": True, "type": "str"},
-        "api_bearer_key": {"required": True, "type": "str"},
+        "api_bearer_key": {"required": True, "type": "str", "no_log": True},
         "agentImageOverride": {"required": False, "type": "str"},
         "description": {"required": False, "type": "str"},
         "desiredAgentImage": {"required": False, "type": "str"},

--- a/plugins/modules/rancher_node.py
+++ b/plugins/modules/rancher_node.py
@@ -146,7 +146,7 @@ def main():
     fields = {
         "name": {"required": True, "type": "str"},
         "rancher_url": {"required": True, "type": "str"},
-        "api_bearer_key": {"required": True, "type": "str"},
+        "api_bearer_key": {"required": True, "type": "str", "no_log": True},
         "force": {"default": False, "type": "bool"},
         "deleteLocalData": {"default": False, "type": "bool"},
         "ignoreDaemonSets": {"default": True, "type": "bool"},


### PR DESCRIPTION
The api_bearer_key should be masked in the output / logs. 